### PR TITLE
Easier cycling of SMTP credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ path/to/your/configs
 - write your own Terraform config by combining modules in `./tfmodules`  (see: `./samples/main.tf`)
   - consider setting `certbot_extra_args` to `--staging` first to test SSL setup
 - plug in Terraform variables
-  - SES username
   - domain name
   - etc
 - initial deploy strategy should be AllAtOnce
@@ -72,6 +71,7 @@ path/to/your/configs
 - change db password on RDS
 - `credstash put discourse_db_password.discourse-dev`
 - `credstash put discourse_smtp_password.discourse-dev`
+- `credstash put discourse_smtp_username.discourse-dev`
 - `./build.sh`
   - builds and tags a Discourse docker image as `vYYYYmmdd-HHMMSS`
 - do a `docker push`: exact command will be printed out by `build.sh`
@@ -85,6 +85,7 @@ same as dev setup except for:
 
 - `credstash put discourse_db_password.discourse-prod`
 - `credstash put discourse_smtp_password.discourse-prod`
+- `credstash put discourse_smtp_username.discourse-prod`
 - deploy script is `./deploy-prod.sh`
   - deploys the same application version as `discourse-dev` environment's
 

--- a/build.sh
+++ b/build.sh
@@ -50,6 +50,6 @@ echo "Built Docker image but it's not pushed yet. Push when you're ready:"
 echo docker push $docker_tag
 
 echo "You may need to (re-)authenticate with ECR:"
-echo aws ecr get-login
+echo aws ecr get-login --no-include-email
 
 # todo: remove unused images

--- a/containers/app.yml
+++ b/containers/app.yml
@@ -52,6 +52,7 @@ run:
         echo Getting credentials
         export DISCOURSE_DB_PASSWORD=$(credstash get discourse_db_password.$DISCOURSE_ENV)
         export DISCOURSE_SMTP_PASSWORD=$(credstash get discourse_smtp_password.$DISCOURSE_ENV)
+        export DISCOURSE_SMTP_USER_NAME=$(credstash get discourse_smtp_username.$DISCOURSE_ENV)
 
         # we need redis to migrate.
         echo Starting Redis

--- a/containers/app.yml
+++ b/containers/app.yml
@@ -39,7 +39,7 @@ hooks:
 ## Remember, this is YAML syntax - you can only have one block with a name
 run:
   - exec: echo "Beginning of custom commands"
-  - exec: apt-get install python3-setuptools python3-dev -y
+  - exec: apt-get update --fix-missing && apt-get install python3-setuptools python3-dev -y
   - exec: easy_install3 pip
   - exec: pip3 install credstash
   - file:

--- a/tfmodules/discourse-eb/main.tf
+++ b/tfmodules/discourse-eb/main.tf
@@ -241,11 +241,6 @@ resource "aws_elastic_beanstalk_environment" "main" {
     value     = "${var.smtp_address}"
   }
   setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "DISCOURSE_SMTP_USER_NAME"
-    value     = "${var.smtp_user_name}"
-  }
-  setting {
     namespace = "aws:elasticbeanstalk:command"
     name      = "DeploymentPolicy"
     value     = "${var.deployment_policy}"

--- a/tfmodules/discourse-eb/variables.tf
+++ b/tfmodules/discourse-eb/variables.tf
@@ -51,8 +51,6 @@ variable "db_host" {}
 
 variable "smtp_address" {}
 
-variable "smtp_user_name" {}
-
 variable "service_role" {
   default = "aws-elasticbeanstalk-service-role"
 }


### PR DESCRIPTION
Before: SMTP username was pulled in through Elastic Beanstalk's environment variable configuration, which is managed by Terraform

After: SMTP username is pulled from credstash. With this setup, you can update the credentials in credstash and simply restart app servers instead of updating the config through Terraform.