### PR TITLE
Update docker

### DIFF
--- a/tfmodules/discourse-eb/main.tf
+++ b/tfmodules/discourse-eb/main.tf
@@ -103,7 +103,7 @@ resource "aws_elastic_beanstalk_environment" "main" {
   name                = "${var.env_name}"
   application         = "${var.app_name}"
   cname_prefix        = "${var.cname_prefix}"
-  solution_stack_name = "64bit Amazon Linux 2016.09 v2.5.0 running Docker 1.12.6"
+  solution_stack_name = "64bit Amazon Linux 2018.03 v2.12.8 running Docker 18.06.1-ce"
 
   tags = "${var.tags}"
 

--- a/tfmodules/discourse-eb/main.tf
+++ b/tfmodules/discourse-eb/main.tf
@@ -103,7 +103,7 @@ resource "aws_elastic_beanstalk_environment" "main" {
   name                = "${var.env_name}"
   application         = "${var.app_name}"
   cname_prefix        = "${var.cname_prefix}"
-  solution_stack_name = "64bit Amazon Linux 2018.03 v2.12.8 running Docker 18.06.1-ce"
+  solution_stack_name = "${var.solution_stack_name}"
 
   tags = "${var.tags}"
 

--- a/tfmodules/discourse-eb/variables.tf
+++ b/tfmodules/discourse-eb/variables.tf
@@ -20,6 +20,10 @@ variable "deployment_policy" {
   default = "Immmutable"
 }
 
+variable "solution_stack_name" {
+  default = "64bit Amazon Linux 2018.03 v2.12.8 running Docker 18.06.1-ce"
+}
+
 variable "hostname" {}
 
 variable "cname_prefix" {}


### PR DESCRIPTION
Update the Docker version in response to [CVE-2019-5736](https://aws.amazon.com/security/security-bulletins/AWS-2019-002/).

The provided version, `2018.03 v2.12.8` seems to be the latest one available, which should be what the bulletin describes. I'm not 100% on this, but docker 18.06.1-ce does not appear to have the fix for the CVE according to the [changelog](https://docs.docker.com/engine/release-notes/).

What is your take on this?